### PR TITLE
Setup Coveralls for project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,19 +57,19 @@ jobs:
         POSTGRES_DB: postgres
         RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
       run: bundle exec rails test:system test
-#    - name: Coveralls Parallel
-#      uses: coverallsapp/github-action@master
-#      with:
-#        github-token: ${{ secrets.github_token }}
-#        flag-name: run-${{ matrix.test_number }}
-#        parallel: true
+    - name: Coveralls Parallel
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        flag-name: run-${{ matrix.test_number }}
+        parallel: true
 
-#  finish:
-#    needs: build
-#    runs-on: ubuntu-latest
-#    steps:
-#    - name: Coveralls Finished
-#      uses: coverallsapp/github-action@master
-#      with:
-#        github-token: ${{ secrets.github_token }}
-#        parallel-finished: true
+  finish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.github_token }}
+        parallel-finished: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 !/log/.keep
 !/tmp/.keep
 
+# Ignore coverage files
+/coverage/*
+
 # Ignore pidfiles, but keep the directory.
 /tmp/pids/*
 !/tmp/pids/

--- a/Gemfile
+++ b/Gemfile
@@ -61,11 +61,11 @@ group :development do
   gem "web-console"
 
   # add RuboCop gems for project
-  gem "rubocop"
-  gem "rubocop-minitest"
-  gem "rubocop-performance"
-  gem "rubocop-rails"
-  gem "rubocop-rake"
+  gem "rubocop", require: false
+  gem "rubocop-minitest", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+  gem "rubocop-rake", require: false
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"
 
@@ -78,4 +78,8 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
   gem "webdrivers"
+
+  # test coverage
+  gem "coveralls_reborn", "~> 0.25.0", require: false
+  gem "simplecov-lcov", "~> 0.8.0", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,11 +84,17 @@ GEM
       xpath (~> 3.2)
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
+    coveralls_reborn (0.25.0)
+      simplecov (>= 0.18.1, < 0.22.0)
+      term-ansicolor (~> 1.6)
+      thor (>= 0.20.3, < 2.0)
+      tins (~> 1.16)
     crass (1.0.6)
     debug (1.6.2)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
     digest (3.1.0)
+    docile (1.4.0)
     erubi (1.11.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -205,6 +211,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov-lcov (0.8.0)
+    simplecov_json_formatter (0.1.4)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -215,10 +228,15 @@ GEM
     stimulus-rails (1.1.0)
       railties (>= 6.0.0)
     strscan (3.0.4)
+    sync (0.5.0)
     tailwindcss-rails (2.0.12-x86_64-linux)
       railties (>= 6.0.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
     thor (1.2.1)
     timeout (0.3.0)
+    tins (1.31.1)
+      sync
     turbo-rails (1.1.1)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -249,6 +267,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   capybara
+  coveralls_reborn (~> 0.25.0)
   debug
   importmap-rails
   jbuilder
@@ -261,6 +280,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rake
   selenium-webdriver
+  simplecov-lcov (~> 0.8.0)
   sprockets-rails
   stimulus-rails
   tailwindcss-rails

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # README
+[![Coverage Status](https://coveralls.io/repos/github/statelesscode/nerd_dice_dot_com/badge.svg?branch=main)](https://coveralls.io/github/statelesscode/nerd_dice_dot_com?branch=main)
 
 This README would normally document whatever steps are necessary to get the
 application up and running.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,20 @@
 ENV["RAILS_ENV"] ||= "test"
+
+require "simplecov"
+
+SimpleCov.start "rails" do
+  if ENV["CI"]
+    require "simplecov-lcov"
+
+    SimpleCov::Formatter::LcovFormatter.config do |c|
+      c.report_with_single_file = true
+      c.single_report_path = "coverage/lcov.info"
+    end
+
+    formatter SimpleCov::Formatter::LcovFormatter
+  end
+end
+
 require_relative "../config/environment"
 require "rails/test_help"
 


### PR DESCRIPTION
Install and setup Coveralls for the project using the model from the nerd_dice setup of Coveralls, but with SimpleCov.start "rails".

* Add a coverage badge to the README
* Make RuboCop gems require: false in the Gemfile
* Uncomment Coveralls actions from main.yml file

Completes #7 Project needs Coveralls set up