### PR TITLE
Allow ApplicationSystemTestCase driver override

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,12 @@
 require "test_helper"
 
+# For configuration and customization of browser driven tests
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  DRIVER = if ENV["BROWSER_TEST_DRIVER"]
+    ENV["BROWSER_TEST_DRIVER"].to_sym
+  else
+    :headless_chrome
+  end
+
+  driven_by :selenium, using: DRIVER, screen_size: [1400, 1400]
 end


### PR DESCRIPTION
Allow for the local developer to provide an override of the default ApplicationSystemTestCase driver of :headless_chrome via the BROWSER_TEST_DRIVER environment variable. This allows for the one-off ability to interact with the browser in non-headless mode for troubleshooting and debugging while keeping the default behavior unchanged.

This will use the default :headless_chrome driver: rails test:system

This will override the default and use :chrome for the current test run: BROWSER_TEST_DRIVER=chrome rails test:system

Completes #10
Allow for ApplicationSystemTest driver to be provided by CLI