### PR TITLE
Allow time for emails to be sent in system tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.1.2'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run Rubocop
       run: bundle exec rubocop --parallel

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -108,4 +108,18 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def get_input_validation_message(current_selector)
     page.find(current_selector).native.attribute("validationMessage")
   end
+
+  # Exectutes a block and then sleeps for a default or specified amount of time
+  #
+  # This is needed for an example situation where a SystemTestCase would send an
+  # email and there is a race condition where the next line of code that needs
+  # the email to be sent executes without the email being added to to the
+  # ActionMailer::Base.deliveries array.
+  #
+  # @param sleep_time DEFAULT 0.05 the amount of time in seconds to sleep after
+  # yielding the block
+  def await_jobs(sleep_time = 0.05)
+    yield
+    sleep sleep_time
+  end
 end

--- a/test/system/devise/concerns/email_changeable.rb
+++ b/test/system/devise/concerns/email_changeable.rb
@@ -39,8 +39,7 @@ module Devise
         @old_email = @user.email
         standard_email_edit_preconditions!
 
-        click_on "Update"
-        assert_text @email_validation_flash
+        update_and_assert_flash!
 
         revisit_registrations_edit!
 
@@ -89,6 +88,15 @@ module Devise
         else
           login_page_assertions!
         end
+      end
+
+      # Clicks on the update button on the email edit page and asserts
+      # the email validation flash is present
+      def update_and_assert_flash!
+        await_jobs do
+          click_on "Update"
+        end
+        assert_text @email_validation_flash
       end
   end
 end

--- a/test/system/devise/lock_and_unlock_test.rb
+++ b/test/system/devise/lock_and_unlock_test.rb
@@ -148,10 +148,10 @@ module Devise
       def unlock_with_resend!
         resend_page_assertions_and_setup!
 
-        click_on "Resend unlock instructions"
+        await_jobs do
+          click_on "Resend unlock instructions"
+        end
 
-        # allow time for emails to catch up
-        sleep 0.1
         new_unlock_email = ActionMailer::Base.deliveries.last
         new_unlock_token = get_token_from_email(new_unlock_email, "unlock_token")
 

--- a/test/system/devise/reconfirm_email_test.rb
+++ b/test/system/devise/reconfirm_email_test.rb
@@ -81,7 +81,9 @@ module Devise
         assert_text "Resend confirmation instructions"
         # reconfirm the email
         fill_in "Email", with: email
-        click_on "Resend confirmation instructions"
+        await_jobs do
+          click_on "Resend confirmation instructions"
+        end
       end
   end
 end

--- a/test/system/devise/reset_password_test.rb
+++ b/test/system/devise/reset_password_test.rb
@@ -27,7 +27,9 @@ module Devise
       standard_reset_password_preconditions!
       fill_in "Email", with: "bademail@example.com"
       assert_no_emails do
-        click_on "Send me reset password instructions"
+        await_jobs do
+          click_on "Send me reset password instructions"
+        end
       end
       assert_text "Email not found"
     end
@@ -123,7 +125,9 @@ module Devise
       # the correct flash message displayed
       def good_email_flow!
         fill_in "Email", with: @user.email
-        click_on "Send me reset password instructions"
+        await_jobs do
+          click_on "Send me reset password instructions"
+        end
         assert_text "You will receive an email with instructions on how to reset " \
                     "your password in a few minutes."
         # reload user and assert password token no longer nil

--- a/test/system/devise/user_sign_up_test.rb
+++ b/test/system/devise/user_sign_up_test.rb
@@ -172,7 +172,9 @@ module Devise
       # state, and then call standard_signup_fill_in to get the form
       # prepared and filled out correctly
       def signup_page_flow!
-        click_on "Sign up" # from link in welcome
+        await_jobs do
+          click_on "Sign up" # from link in welcome
+        end
         sign_up_page_assertions!
         standard_signup_fill_in
       end


### PR DESCRIPTION
In certain situations in the Devise tests, there were tests failing frequently or intermittently because not enough time elapsed following a line of code where an email was sent before the next line of code was executed. This seems to be isolated to system tests, so created a method in ApplicationSystemTestCase that yields the block and then sleeps.

Modified the Devise test cases where emails are being sent so they enclose actions that trigger emails in an await_jobs block.

Fixes #18 Tests that depend upon emails being sent can fail if not enough time elapses before assertion that depends upon it