### PR TITLE
Refactor TailwindHelper to stop at border

### DIFF
--- a/app/helpers/tailwind_helper.rb
+++ b/app/helpers/tailwind_helper.rb
@@ -1,7 +1,7 @@
 # NerdDice.com TailwindHelper
 #
-# The purpose of this helper is to have granular individual HTML classes
-# available in the DOM so that we can manipulate them using Stimulus.
+# The purpose of this helper module is to have granular individual HTML
+# classes available in the DOM so that we can manipulate them using Stimulus.
 #
 # This provides a workable middle ground during development where you
 # don't lose the granularity of the individual classes like you would by
@@ -13,41 +13,16 @@
 # components into Tailwind Directives, but during early stage design and
 # iteration, the Rails helper approach is easier to work with.
 #
-# TODO: The reusable component boundaries should end at the edge of the
+# IMPORTANT:
+# The reusable component boundaries should always end at the edge of the
 # border margin and positioning should be handled by the particular view
 # to allow for better flexibility for layout and positioning.
+#
+# Individual themes of related functionality are in their own submodules
+# which are included by this module.
 module TailwindHelper
-  def tw_success_button
-    join_classes(
-      %w[font-semibold text-gray-100 bg-blue-500 hover:bg-blue-800 px-3 py-1 mt-1 mb-2 rounded-lg]
-    )
-  end
-
-  def tw_cancel_button
-    join_classes(
-      %w[font-semibold text-gray-600 bg-gray-200 border-2 border-gray-500 hover:bg-gray-500 hover:text-gray-200 px-3
-         py-1 mt-1 mb-2 rounded-lg]
-    )
-  end
-
-  def tw_alert_button
-    join_classes(
-      %w[font-semibold text-gray-100 bg-red-500 border-2 border-red-500 hover:bg-gray-800 hover:text-gray-200 px-3 py-1
-         mt-1 mb-2 rounded-lg]
-    )
-  end
-
-  def tw_standard_link
-    join_classes(%w[text-blue-600 hover:underline hover:text-blue-800 visited:text-purple-600])
-  end
-
-  def tw_h1
-    join_classes(%w[font-bold text-4xl])
-  end
-
-  def tw_h2
-    join_classes(%w[font-bold text-3xl])
-  end
+  include ButtonHelper
+  include TypographyHelper
 
   # joins an array of classes with a space
   def join_classes(class_array)

--- a/app/helpers/tailwind_helper/button_helper.rb
+++ b/app/helpers/tailwind_helper/button_helper.rb
@@ -1,0 +1,34 @@
+module TailwindHelper
+  # NerdDice.com TailwindHelper::ButtonHelper
+  #
+  # This module is dedicated to styling for buttons.
+  # If changes should apply to all buttons, the tw_base_button method should be modified
+  #
+  # Follow the implementation pattern of combining tw_base_button with the additional
+  # tailwind classes needed.
+  module ButtonHelper
+    def tw_base_button
+      join_classes(
+        %w[font-semibold px-3 py-1 rounded-lg]
+      )
+    end
+
+    def tw_success_button
+      "#{tw_base_button} #{join_classes(
+        %w[text-gray-100 bg-blue-500 hover:bg-blue-800]
+      )}"
+    end
+
+    def tw_cancel_button
+      "#{tw_base_button} #{join_classes(
+        %w[text-gray-600 bg-gray-200 border-2 border-gray-500 hover:bg-gray-500 hover:text-gray-200]
+      )}"
+    end
+
+    def tw_alert_button
+      "#{tw_base_button} #{join_classes(
+        %w[text-gray-100 bg-red-500 border-2 border-red-500 hover:bg-gray-800 hover:text-gray-200]
+      )}"
+    end
+  end
+end

--- a/app/helpers/tailwind_helper/typography_helper.rb
+++ b/app/helpers/tailwind_helper/typography_helper.rb
@@ -1,0 +1,22 @@
+module TailwindHelper
+  # NerdDice.com TailwindHelper::TypographyHelper
+  #
+  # This module is dedicated to styling for fonts, typography and elements
+  # related to text.
+  #
+  # Follow the implementation pattern of refactoring out repeated classes
+  # into sub-methods that can be reused when applicable.
+  module TypographyHelper
+    def tw_standard_link
+      join_classes(%w[text-blue-600 hover:underline hover:text-blue-800 visited:text-purple-600])
+    end
+
+    def tw_h1
+      join_classes(%w[font-bold text-4xl])
+    end
+
+    def tw_h2
+      join_classes(%w[font-bold text-3xl])
+    end
+  end
+end

--- a/app/views/authenticated/index.html.erb
+++ b/app/views/authenticated/index.html.erb
@@ -3,5 +3,5 @@
   <p>Find me in app/views/authenticated/index.html.erb</p>
   <p><%= link_to "Back to welcome page", root_path, class: tw_standard_link %></p>
   <p><%= link_to "Manage your account", edit_user_registration_path, class: tw_standard_link %></p>
-  <p><%= button_to "Log out", destroy_user_session_path, method: :delete, class: tw_cancel_button %></p>
+  <p><%= button_to "Log out", destroy_user_session_path, method: :delete, class: "mt-1 mb-2 #{tw_cancel_button}" %></p>
 </div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <div class="actions">
-      <%= f.submit "Resend confirmation instructions", class: tw_success_button %>
+      <%= f.submit "Resend confirmation instructions", class: "mt-1 mb-2 #{tw_success_button}" %>
     </div>
   <% end %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -19,7 +19,7 @@
     </div>
 
     <div class="actions">
-      <%= f.submit "Change my password", class: tw_success_button %>
+      <%= f.submit "Change my password", class: "mt-1 mb-2 #{tw_success_button}" %>
     </div>
   <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <div class="actions">
-      <%= f.submit "Send me reset password instructions", class: tw_success_button %>
+      <%= f.submit "Send me reset password instructions", class: "mt-1 mb-2 #{tw_success_button}" %>
     </div>
   <% end %>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -33,13 +33,13 @@
     </div>
 
     <div class="actions">
-      <%= f.submit "Update", class: tw_success_button %>
+      <%= f.submit "Update", class: "mt-1 mb-2 #{tw_success_button}" %>
     </div>
   <% end %>
 
   <h3>Cancel my account</h3>
 
-  <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), form: { data: { turbo_confirm: "Are you sure?" } }, method: :delete, class: tw_alert_button %></p>
+  <p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), form: { data: { turbo_confirm: "Are you sure?" } }, method: :delete, class: "mt-1 mb-2 #{tw_alert_button}" %></p>
 
   <%= link_to "Back", :back, class: tw_standard_link %>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -23,7 +23,7 @@
     </div>
 
     <div class="actions">
-      <%= f.submit "Sign up", class: tw_success_button %>
+      <%= f.submit "Sign up", class: "mt-1 mb-2 #{tw_success_button}" %>
     </div>
   <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -20,7 +20,7 @@
     <% end %>
 
     <div class="actions">
-      <%= f.submit "Log in", class: tw_success_button %>
+      <%= f.submit "Log in", class: "mt-1 mb-2 #{tw_success_button}" %>
     </div>
   <% end %>
 

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -10,7 +10,7 @@
     </div>
 
     <div class="actions">
-      <%= f.submit "Resend unlock instructions", class: tw_success_button %>
+      <%= f.submit "Resend unlock instructions", class: "mt-1 mb-2 #{tw_success_button}" %>
     </div>
   <% end %>
 

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -3,7 +3,7 @@
   <% if current_user %>
     <p><%= link_to "Visit the members' area", authenticated_path, class: tw_standard_link %></p>
     <p><%= link_to "Manage your account", edit_user_registration_path, class: tw_standard_link %></p>
-    <p><%= button_to "Log out", destroy_user_session_path, method: :delete, class: tw_cancel_button %></p>
+    <p><%= button_to "Log out", destroy_user_session_path, method: :delete, class: "mt-1 mb-2 #{tw_cancel_button}" %></p>
   <% else %>
     <p><%= link_to "Sign up", new_user_registration_path, class: tw_standard_link %></p>
     <p><%= link_to "Log in", new_user_session_path, class: tw_standard_link %></p>

--- a/test/helpers/tailwind_helper/button_helper_test.rb
+++ b/test/helpers/tailwind_helper/button_helper_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+require "./app/helpers/tailwind_helper"
+
+module TailwindHelper
+  # Tests for the TailwindHelper::ButtonHelper methods
+  # See ../tailwind_helper_test.rb for more info
+  class ButtonHelperTest < ActionView::TestCase
+    include TailwindHelper
+
+    test "tw_base_button works as intended" do
+      assert_equal "font-semibold px-3 py-1 rounded-lg", tw_base_button
+    end
+
+    test "tw_success_button works as intended" do
+      assert_equal "font-semibold px-3 py-1 rounded-lg text-gray-100 bg-blue-500 hover:bg-blue-800",
+                   tw_success_button
+    end
+
+    test "tw_cancel_button works as intended" do
+      assert_equal "font-semibold px-3 py-1 rounded-lg text-gray-600 bg-gray-200 border-2 " \
+                   "border-gray-500 hover:bg-gray-500 hover:text-gray-200",
+                   tw_cancel_button
+    end
+
+    test "tw_alert_button works as intended" do
+      assert_equal "font-semibold px-3 py-1 rounded-lg text-gray-100 bg-red-500 border-2 " \
+                   "border-red-500 hover:bg-gray-800 hover:text-gray-200",
+                   tw_alert_button
+    end
+  end
+end

--- a/test/helpers/tailwind_helper/typography_helper_test.rb
+++ b/test/helpers/tailwind_helper/typography_helper_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+module TailwindHelper
+  # Tests for the TailwindHelper::ButtonHelper methods
+  # See ../tailwind_helper_test.rb for more info
+  class TypographyHelperTest < ActionView::TestCase
+    include TailwindHelper
+
+    test "tw_standard_link works as intended" do
+      assert_equal "text-blue-600 hover:underline hover:text-blue-800 visited:text-purple-600", tw_standard_link
+    end
+
+    test "tw_h1 works as intended" do
+      assert_equal "font-bold text-4xl", tw_h1
+    end
+
+    test "tw_h2 works as intended" do
+      assert_equal "font-bold text-3xl", tw_h2
+    end
+  end
+end

--- a/test/helpers/tailwind_helper_test.rb
+++ b/test/helpers/tailwind_helper_test.rb
@@ -1,39 +1,15 @@
+require "test_helper"
+
 # Tests for the TailwindHelper methods
 #
 # While these might seem a bit tedious and pointless, they are handy
 # for ensuring that refactoring the Helpers produces the intended
 # results.
 #
-# In the event that the TailwindHelper is broken down into more modular
-# code files, the tests should be restructured to match
+# TailwindHelper is broken down into submodules the structure of the
+# test classes should match the structure of the module files
 class TailwindHelperTest < ActionView::TestCase
-  test "tw_success_button works as intended" do
-    assert_equal "font-semibold text-gray-100 bg-blue-500 hover:bg-blue-800 " \
-                 "px-3 py-1 mt-1 mb-2 rounded-lg",
-                 tw_success_button
-  end
-
-  test "tw_cancel_button works as intended" do
-    assert_equal "font-semibold text-gray-600 bg-gray-200 border-2 border-gray-500 " \
-                 "hover:bg-gray-500 hover:text-gray-200 px-3 py-1 mt-1 mb-2 rounded-lg",
-                 tw_cancel_button
-  end
-
-  test "tw_alert_button works as intended" do
-    assert_equal "font-semibold text-gray-100 bg-red-500 border-2 border-red-500 " \
-                 "hover:bg-gray-800 hover:text-gray-200 px-3 py-1 mt-1 mb-2 rounded-lg",
-                 tw_alert_button
-  end
-
-  test "tw_standard_link works as intended" do
-    assert_equal "text-blue-600 hover:underline hover:text-blue-800 visited:text-purple-600", tw_standard_link
-  end
-
-  test "tw_h1 works as intended" do
-    assert_equal "font-bold text-4xl", tw_h1
-  end
-
-  test "tw_h2 works as intended" do
-    assert_equal "font-bold text-3xl", tw_h2
+  test "join_classes works as expected" do
+    assert_equal "foo bar baz", join_classes(%w[foo bar baz])
   end
 end


### PR DESCRIPTION
Refactor the implementation of the TailwindHelper methods to stop at the border of the element and leave the implementation of margin and positioning to the particular view. This prevents the issue of trying to take away margin you don't want from an included component.

Also did some overall refactoring of the module by splitting it into submodules and adding a tw_base_button method that the other button methods inherit from.

Modified the views to use the modified methods and have them handle the margin.

Completes #24 Refactor Tailwind helper code