### PR TITLE
Set Devise to paranoid mode and adjust tests

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -117,7 +117,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/test/helpers/tailwind_helper/button_helper_test.rb
+++ b/test/helpers/tailwind_helper/button_helper_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "./app/helpers/tailwind_helper"
 
 module TailwindHelper
   # Tests for the TailwindHelper::ButtonHelper methods

--- a/test/system/devise/reset_password_test.rb
+++ b/test/system/devise/reset_password_test.rb
@@ -14,6 +14,8 @@ module Devise
     setup do
       @user = users(:dm)
       @new_password = "Freddie91Mercury"
+      @paranoid_instructions = "If your email address exists in our database, you " \
+                               "will receive a password recovery link at your email address in a few minutes."
     end
 
     test "user can reset password with valid email and token" do
@@ -31,7 +33,7 @@ module Devise
           click_on "Send me reset password instructions"
         end
       end
-      assert_text "Email not found"
+      assert_text @paranoid_instructions
     end
 
     test "user cannot reset password with an invalid token" do
@@ -128,8 +130,7 @@ module Devise
         await_jobs do
           click_on "Send me reset password instructions"
         end
-        assert_text "You will receive an email with instructions on how to reset " \
-                    "your password in a few minutes."
+        assert_text @paranoid_instructions
         # reload user and assert password token no longer nil
         @user.reload
         assert_not_nil @user.reset_password_token


### PR DESCRIPTION
Set Devise to paranoid mode to prevent against malicious users receiving feedback about whether an account exists in the database or not.

See Testing for User Enumeration and Guessable User Account (OWASP-AT-002) and Devise paranoid mode on Wiki for more information.

Uncommented paranoid setting to turn on paranoid mode and adjusted existing Devise system tests to account for the new behavior. Put an item in the backlog to re-evaluate whether to change the locking and unlocking messaging to account for paranoid mode.

Completes #25 Make Devise paranoid